### PR TITLE
Fix 19 outlined select BLUI-2769

### DIFF
--- a/src/components/material-ui/inputs/select/OutlinedSelect.tsx
+++ b/src/components/material-ui/inputs/select/OutlinedSelect.tsx
@@ -51,7 +51,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} className={classes.formControl}>
                         <InputLabel>Label</InputLabel>
-                        <Select value={age} onChange={handleChange}>
+                        <Select value={age} onChange={handleChange} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>
@@ -68,7 +68,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} disabled className={classes.formControl}>
                         <InputLabel>Label</InputLabel>
-                        <Select value={age}>
+                        <Select value={age} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>
@@ -85,7 +85,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} className={classes.formControl} error>
                         <InputLabel>Label</InputLabel>
-                        <Select value={age} onChange={handleChange}>
+                        <Select value={age} onChange={handleChange} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>
@@ -107,7 +107,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} className={classes.formControl} color="primary">
                         <InputLabel>Label</InputLabel>
-                        <Select value={age} onChange={handleChange}>
+                        <Select value={age} onChange={handleChange} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>
@@ -124,7 +124,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} disabled className={classes.formControl} color="primary">
                         <InputLabel>Label</InputLabel>
-                        <Select value={age}>
+                        <Select value={age} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>
@@ -141,7 +141,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} className={classes.formControl} error color="primary">
                         <InputLabel>Label</InputLabel>
-                        <Select value={age} onChange={handleChange}>
+                        <Select value={age} onChange={handleChange} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>
@@ -163,7 +163,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} className={classes.formControl} color="secondary">
                         <InputLabel>Label</InputLabel>
-                        <Select value={age} onChange={handleChange}>
+                        <Select value={age} onChange={handleChange} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>
@@ -180,7 +180,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} disabled className={classes.formControl} color="secondary">
                         <InputLabel>Label</InputLabel>
-                        <Select value={age}>
+                        <Select value={age} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>
@@ -197,7 +197,7 @@ export const OutlinedSelectExample: React.FC = () => {
                     </Typography>
                     <FormControl variant={'outlined'} className={classes.formControl} error color="secondary">
                         <InputLabel>Label</InputLabel>
-                        <Select value={age} onChange={handleChange}>
+                        <Select value={age} onChange={handleChange} label={'Label'}>
                             <MenuItem value="">
                                 <em>None</em>
                             </MenuItem>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # https://github.com/brightlayer-ui/react-themes/issues/19.

This ended up not a theme issue, just adjustment in showcase
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- update select to have label prop
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start
- http://localhost:3000/material-ui-components/input-components
- Outlined Select examples

-before
![image](https://user-images.githubusercontent.com/37150565/151424038-383052b7-5ec9-45d5-ac59-ce63f6cd7a83.png)

-after
![image](https://user-images.githubusercontent.com/37150565/151424097-ff771c32-dc8e-45da-acd0-98a95151a635.png)

