### PR TITLE
Feature/2848 34 remove padding none for th

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## v2.0.1
-
-### Changed
-
--   Updated `<TableCell>` padding for table header cells ([#34](https://github.com/brightlayer-ui/react-themes/issues/34)).
-
 ## v2.0.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.0.1
+
+### Changed
+
+-   Updated `<TableCell>` padding for table header cells ([#34](https://github.com/brightlayer-ui/react-themes/issues/34)).
+
 ## v2.0.0
 
 ### Changed

--- a/src/components/material-ui/data-display/Table.tsx
+++ b/src/components/material-ui/data-display/Table.tsx
@@ -312,7 +312,7 @@ export const TableExample: React.FC = () => {
                                                 inputProps={{ 'aria-labelledby': labelId }}
                                             />
                                         </TableCell>
-                                        <TableCell component="th" id={labelId} scope="row" padding="none">
+                                        <TableCell component="th" id={labelId} scope="row">
                                             {row.name}
                                         </TableCell>
                                         <TableCell align="right">{row.calories}</TableCell>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #34

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Removed padding none from table header cells

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1778" alt="Screenshot 2022-02-02 at 4 50 54 PM" src="https://user-images.githubusercontent.com/25982779/152144975-07f6e65c-b8f7-41af-bef4-25e83b6c8948.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start
- Go to Material Components --> Data Display --> Table
