### PR TITLE
fix: issue#31: moves the navigation icon before the title

### DIFF
--- a/src/components/SharedAppBar.tsx
+++ b/src/components/SharedAppBar.tsx
@@ -39,6 +39,8 @@ export const SharedAppBar = (props: SharedAppBarProps): JSX.Element => {
                     dispatch({ type: TOGGLE_DRAWER });
                 }}
                 size="large"
+                edge={'start'}
+                sx={{mr: 2.5}}
             >
                 <Menu />
             </IconButton>

--- a/src/components/SharedAppBar.tsx
+++ b/src/components/SharedAppBar.tsx
@@ -48,10 +48,10 @@ export const SharedAppBar = (props: SharedAppBarProps): JSX.Element => {
     return (
         <AppBar position={'sticky'} color={'primary'} sx={{ zIndex: 10000 }}>
             <Toolbar>
+                {getNavigationIcon()}
                 <Typography variant="h6" sx={{ fontWeight: 600, lineHeight: 1 }}>
                     {title}
                 </Typography>
-                {getNavigationIcon()}
                 <Spacer flex={1} />
                 <Tooltip title={'Toggle Theme'} aria-label={'toggle the theme of the current showcase'}>
                     <IconButton


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [#31](https://github.com/brightlayer-ui/react-showcase-demo/issues/31).

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- move the navigation icon before the title

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="516" alt="image" src="https://user-images.githubusercontent.com/13744352/193417412-1749a42b-6ab8-40c8-8617-0bb52ba12d63.png">
