### PR TITLE
Move menu position to the left of the title

### DIFF
--- a/src/components/SharedAppBar.tsx
+++ b/src/components/SharedAppBar.tsx
@@ -48,10 +48,10 @@ export const SharedAppBar = (props: SharedAppBarProps): JSX.Element => {
     return (
         <AppBar position={'sticky'} color={'primary'} sx={{ zIndex: 10000 }}>
             <Toolbar>
+                {getNavigationIcon()}
                 <Typography variant="h6" sx={{ fontWeight: 600, lineHeight: 1 }}>
                     {title}
                 </Typography>
-                {getNavigationIcon()}
                 <Spacer flex={1} />
                 <Tooltip title={'Toggle Theme'} aria-label={'toggle the theme of the current showcase'}>
                     <IconButton


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #31.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Move the menu icon to the left of the title when the screen width is below 600px.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![menu-on-left](https://user-images.githubusercontent.com/34067162/193407843-8e8aad0b-ffab-47b5-9458-b36c0577dbd6.png)


